### PR TITLE
Auto rename terminal tabs

### DIFF
--- a/lib/clickable-npm-scripts-view.js
+++ b/lib/clickable-npm-scripts-view.js
@@ -37,6 +37,8 @@ export default class ClickableNpmScriptsView {
 					 }
 					 try{
 						 terminal.run([`npm run ${script}`]);
+						 const terminalViews = terminal.getTerminalViews();
+						 terminalViews[terminalViews.length-1].statusIcon.innerHTML = `<i class="icon icon-terminal"></i><span class="name"> ${script} </span>`;
 					 }catch(err){
 						 console.error(err);
 						 atom.notifications.addFatalError('A Fatal error occurred', {


### PR DESCRIPTION
Hi. Currently, I have to right-click-rename every terminal tab (which I hate doing). These changes automatically rename the new tab when user clicks on a script. Should it perhaps be toggleable in settings if not auto-renaming is intentional?